### PR TITLE
check for the variable type for fprintf L190

### DIFF
--- a/preprocess.m
+++ b/preprocess.m
@@ -187,7 +187,12 @@ P.b = P.b(row_norms>1e-6,:);
 
 %maybe add LP presolve here
 
-fprintf('Removed %d zero rows\n', sum(row_norms>1e-6));
+%Aga: add check if sum(row_norms>1e-6) is sparse
+if issparse(sum(row_norms>1e-6))
+    fprintf('Removed %d zero rows\n', full(sum(row_norms>1e-6)));
+else
+    fprintf('Removed %d zero rows\n', sum(row_norms>1e-6));
+end
 
 %scale the matrix to help with numerical precision
 dim = size(P.A,2);


### PR DESCRIPTION
Hi, 
I came across the error using the newest Matlab version (2019a), using Gurobi solver, on Linux. Shortly the variable sum(row_norms>1e-6) is of a sparse double type, which causes the fprintf to exit with error (as it expect double). I added a simple if statement that checks whether the sum(row_norms>1e-6) is a sparse and then uses full(sum(row_norms>1e-6)) as an input for fprintf. If it is not sparse then the code is left unchanged. This fully restored the function usability. 

Regards,
Aga